### PR TITLE
Issue #18: Make `DragDropStage` open at the dropped location and be ownerless

### DIFF
--- a/core/src/main/java/software/coley/bentofx/building/StageBuilding.java
+++ b/core/src/main/java/software/coley/bentofx/building/StageBuilding.java
@@ -1,10 +1,14 @@
 package software.coley.bentofx.building;
 
+import javafx.collections.ObservableList;
+import javafx.geometry.Bounds;
 import javafx.geometry.Point2D;
+import javafx.geometry.Rectangle2D;
 import javafx.geometry.Side;
 import javafx.scene.Scene;
 import javafx.scene.layout.Region;
 import javafx.scene.robot.Robot;
+import javafx.stage.Screen;
 import javafx.stage.Stage;
 import javafx.stage.Window;
 import org.jspecify.annotations.Nullable;
@@ -24,7 +28,7 @@ public class StageBuilding {
 	private final Bento bento;
 	private StageFactory stageFactory = DEFAULT_STAGE_FACTORY;
 	private SceneFactory sceneFactory = DEFAULT_SCENE_FACTORY;
-	private boolean applyMousePosition = true;
+	private boolean applyMousePosition = false;
 	private boolean applySourceAsOwner = true;
 
 	public StageBuilding(Bento bento) {
@@ -131,8 +135,23 @@ public class StageBuilding {
 		if (applyMousePosition) {
 			final Robot robot = new Robot();
 			final Point2D mousePosition = robot.getMousePosition();
-			stage.setX(mousePosition.getX());
-			stage.setY(mousePosition.getY());
+
+			// Clamp the position to the screen bounds.
+			// We don't want a new stage that spawns on the bottom or right edge of the screen to be inaccessible.
+			double x = mousePosition.getX();
+			double y = mousePosition.getY();
+			ObservableList<Screen> screens = Screen.getScreensForRectangle(x, y, x + 1, y + 1);
+			if (!screens.isEmpty()) {
+				final Bounds dockableContainerBounds = leaf.getBoundsInLocal();
+				final Rectangle2D screenBounds = screens.getFirst().getVisualBounds();
+				final double maxX = screenBounds.getMaxX() - dockableContainerBounds.getWidth();
+				final double maxY = screenBounds.getMaxY() - dockableContainerBounds.getHeight();
+				x = Math.min(x, maxX);
+				y = Math.min(y, maxY);
+			}
+
+			stage.setX(x);
+			stage.setY(y);
 		}
 
 		return stage;

--- a/core/src/main/java/software/coley/bentofx/building/StageBuilding.java
+++ b/core/src/main/java/software/coley/bentofx/building/StageBuilding.java
@@ -24,6 +24,8 @@ public class StageBuilding {
 	private final Bento bento;
 	private StageFactory stageFactory = DEFAULT_STAGE_FACTORY;
 	private SceneFactory sceneFactory = DEFAULT_SCENE_FACTORY;
+	private boolean applyMousePosition = false;
+	private boolean sourceIsOwner = true;
 
 	public StageBuilding(@NonNull Bento bento) {
 		this.bento = bento;
@@ -95,42 +97,6 @@ public class StageBuilding {
 	                                         @NonNull DockContainerLeaf leaf,
 	                                         @NonNull Dockable dockable,
 	                                         double width, double height) {
-		return newStageForDockable(sourceScene, root, leaf, dockable, width, height, false, true);
-	}
-
-	/**
-	 * Create a new stage for the given dockable.,
-	 *
-	 * @param sourceScene
-	 * 		Original scene to copy state from.
-	 * @param root
-	 * 		Newly created root branch to place into the resulting stage.
-	 * @param leaf
-	 * 		Newly created leaf container to place the dockable into.
-	 * @param dockable
-	 * 		Dockable to place into the newly created stage.
-	 * @param width
-	 * 		Preferred stage width.
-	 * @param height
-	 * 		Preferred stage height.
-	 * @param sourceIsOwner
-	 *        {@code true} to invoke {@link Stage#initOwner(Window)}, where the
-	 * 		owner is the source stage.
-	 * @param applyMousePosition
-	 *        {@code true} to set the stage's X and Y positions to the position of
-	 * 		the mouse when the new stage is created.
-	 *
-	 * @return Newly created stage.
-	 */
-	public DragDropStage newStageForDockable(@Nullable Scene sourceScene,
-	                                         @NonNull DockContainerRootBranch root,
-	                                         @NonNull DockContainerLeaf leaf,
-	                                         @NonNull Dockable dockable,
-	                                         double width,
-	                                         double height,
-	                                         boolean sourceIsOwner,
-	                                         boolean applyMousePosition
-	) {
 		// Sanity check, leaf shouldn't have an existing parent.
 		if (leaf.getParentContainer() != root && leaf.getParentContainer() != null)
 			leaf.removeFromParent();
@@ -216,5 +182,13 @@ public class StageBuilding {
 		if (factory == null)
 			factory = DEFAULT_SCENE_FACTORY;
 		sceneFactory = factory;
+	}
+
+	public void setSourceIsOwner(boolean sourceIsOwner) {
+		this.sourceIsOwner = sourceIsOwner;
+	}
+
+	public void setApplyMousePosition(boolean applyMousePosition) {
+		this.applyMousePosition = applyMousePosition;
 	}
 }

--- a/core/src/main/java/software/coley/bentofx/building/StageBuilding.java
+++ b/core/src/main/java/software/coley/bentofx/building/StageBuilding.java
@@ -1,8 +1,10 @@
 package software.coley.bentofx.building;
 
+import javafx.geometry.Point2D;
 import javafx.geometry.Side;
 import javafx.scene.Scene;
 import javafx.scene.layout.Region;
+import javafx.scene.robot.Robot;
 import javafx.stage.Stage;
 import javafx.stage.Window;
 import org.jspecify.annotations.Nullable;
@@ -22,8 +24,8 @@ public class StageBuilding {
 	private final Bento bento;
 	private StageFactory stageFactory = DEFAULT_STAGE_FACTORY;
 	private SceneFactory sceneFactory = DEFAULT_SCENE_FACTORY;
-	private boolean applyMousePosition = false;
-	private boolean sourceIsOwner = true;
+	private boolean applyMousePosition = true;
+	private boolean applySourceAsOwner = true;
 
 	public StageBuilding(Bento bento) {
 		this.bento = bento;
@@ -123,7 +125,15 @@ public class StageBuilding {
 
 		// Copy properties from the source scene/stage.
 		if (sourceScene != null)
-			initializeFromSource(sourceScene, scene, sourceStage, stage, true);
+			initializeFromSource(sourceScene, scene, sourceStage, stage, applySourceAsOwner);
+
+		// Position the stage at the mouse position, if enabled.
+		if (applyMousePosition) {
+			final Robot robot = new Robot();
+			final Point2D mousePosition = robot.getMousePosition();
+			stage.setX(mousePosition.getX());
+			stage.setY(mousePosition.getY());
+		}
 
 		return stage;
 	}
@@ -186,10 +196,23 @@ public class StageBuilding {
 		sceneFactory = factory;
 	}
 
-	public void setSourceIsOwner(boolean sourceIsOwner) {
-		this.sourceIsOwner = sourceIsOwner;
+	/**
+	 * @param applySourceAsOwner
+	 *        {@code true} to make newly created stages have their owner set to the source stage the dockable is being dragged out of.
+	 *        {@code false} to not set an owner, allowing the new stage to be handled independently of the source stage.
+	 *
+	 * @see Stage#initOwner(Window)
+	 */
+	public void setApplySourceAsOwner(boolean applySourceAsOwner) {
+		this.applySourceAsOwner = applySourceAsOwner;
 	}
 
+	/**
+	 *
+	 * @param applyMousePosition
+	 *        {@code true} to position newly created stages at the current mouse position.
+	 *        {@code false} to not apply any special positioning, allowing the stage to be positioned automatically <i>(Generally centered)</i>.
+	 */
 	public void setApplyMousePosition(boolean applyMousePosition) {
 		this.applyMousePosition = applyMousePosition;
 	}


### PR DESCRIPTION
These changes allow the default behavior defined in the issue without adding top-level properties to the `Bento` class.

New default behavior when undocking a `Dockable` to a `DragDropStage:
* Open the `DragDropStage` at the dropped location.
* Make the `DragDropStage` ownerless.

