### PR TITLE
documentation/issue-45: Use inline ``{@return ...}`` tag for Javadoc summaries missing from the public API

### DIFF
--- a/core/src/main/java/software/coley/bentofx/Bento.java
+++ b/core/src/main/java/software/coley/bentofx/Bento.java
@@ -66,56 +66,56 @@ public class Bento {
 	}
 
 	/**
-	 * @return Bus for handling event firing and event listeners.
+	 * {@return bus for handling event firing and event listeners}
 	 */
 	public EventBus events() {
 		return eventBus;
 	}
 
 	/**
-	 * @return Search operations.
+	 * {@return search operations}
 	 */
 	public SearchHandler search() {
 		return searchHandler;
 	}
 
 	/**
-	 * @return Builders for {@link DragDropStage}.
+	 * {@return builders for {@link DragDropStage}}
 	 */
 	public StageBuilding stageBuilding() {
 		return stageBuilding;
 	}
 
 	/**
-	 * @return Builders for various bento UI controls.
+	 * {@return builders for various bento UI controls}
 	 */
 	public ControlsBuilding controlsBuilding() {
 		return controlsBuilding;
 	}
 
 	/**
-	 * @return Builders for {@link DockContainer} and {@link Dockable}.
+	 * {@return builders for {@link DockContainer} and {@link Dockable}}
 	 */
 	public DockBuilding dockBuilding() {
 		return dockBuilding;
 	}
 
 	/**
-	 * @return Builders for placeholder content.
+	 * {@return builders for placeholder content}
 	 */
 	public PlaceholderBuilding placeholderBuilding() {
 		return placeholderBuilding;
 	}
 
 	/**
-	 * @return Behavior implementation for drag-drop operations.
+	 * {@return behavior implementation for drag-drop operations}
 	 */
 	public DockableDragDropBehavior getDragDropBehavior() {
 		return dragDropBehavior;
 	}
 
 	/**
-	 * @return Behavior implementation for click operations.
+	 * {@return behavior implementation for click operations}
 	 */
 	public DockableClickBehavior getClickBehavior() {
 		return clickBehavior;
@@ -132,10 +132,10 @@ public class Bento {
 	}
 
 	/**
+	 * {@return {@code true} when registered}
+	 *
 	 * @param container
 	 * 		Root container to register.
-	 *
-	 * @return {@code true} when registered.
 	 */
 	public boolean registerRoot(DockContainerRootBranch container) {
 		if (!rootContainers.contains(container)) {
@@ -147,10 +147,10 @@ public class Bento {
 	}
 
 	/**
+	 * {@return {@code true} when unregistered}
+	 *
 	 * @param container
 	 * 		Root container to unregister.
-	 *
-	 * @return {@code true} when unregistered.
 	 */
 	public boolean unregisterRoot(DockContainerRootBranch container) {
 		if (rootContainers.remove(container)) {

--- a/core/src/main/java/software/coley/bentofx/BentoBacked.java
+++ b/core/src/main/java/software/coley/bentofx/BentoBacked.java
@@ -7,7 +7,7 @@ package software.coley.bentofx;
  */
 public interface BentoBacked {
 	/**
-	 * @return Bento instance responsible for this object.
+	 * {@return Bento instance responsible for this object}
 	 */
 	Bento getBento();
 }

--- a/core/src/main/java/software/coley/bentofx/building/CanvasFactory.java
+++ b/core/src/main/java/software/coley/bentofx/building/CanvasFactory.java
@@ -10,10 +10,10 @@ import software.coley.bentofx.layout.container.DockContainerLeaf;
  */
 public interface CanvasFactory {
 	/**
+	 * {@return new canvas}
+	 *
 	 * @param container
 	 * 		Parent container.
-	 *
-	 * @return New canvas.
 	 */
 	PixelCanvas newCanvas(DockContainerLeaf container);
 }

--- a/core/src/main/java/software/coley/bentofx/building/ContentWrapperFactory.java
+++ b/core/src/main/java/software/coley/bentofx/building/ContentWrapperFactory.java
@@ -11,10 +11,10 @@ import software.coley.bentofx.layout.container.DockContainerLeaf;
  */
 public interface ContentWrapperFactory {
 	/**
+	 * {@return newly created content wrapper}
+	 *
 	 * @param container
 	 * 		Parent container.
-	 *
-	 * @return Newly created content wrapper.
 	 */
 	ContentWrapper newContentWrapper(DockContainerLeaf container);
 }

--- a/core/src/main/java/software/coley/bentofx/building/ControlsBuilding.java
+++ b/core/src/main/java/software/coley/bentofx/building/ControlsBuilding.java
@@ -29,7 +29,7 @@ public class ControlsBuilding implements HeaderPaneFactory, HeadersFactory, Head
 	private CanvasFactory canvasFactory = DEFAULT_CANVAS_FACTORY;
 
 	/**
-	 * @return Factory for creating {@link HeaderPane}.
+	 * {@return factory for creating {@link HeaderPane}}
 	 */
 	public HeaderPaneFactory getHeaderPaneFactory() {
 		return headerPaneFactory;
@@ -47,7 +47,7 @@ public class ControlsBuilding implements HeaderPaneFactory, HeadersFactory, Head
 	}
 
 	/**
-	 * @return Factory for creating {@link Headers}.
+	 * {@return factory for creating {@link Headers}}
 	 */
 	public HeadersFactory getHeadersFactory() {
 		return headersFactory;
@@ -65,7 +65,7 @@ public class ControlsBuilding implements HeaderPaneFactory, HeadersFactory, Head
 	}
 
 	/**
-	 * @return Factory for creating {@link Header}.
+	 * {@return factory for creating {@link Header}}
 	 */
 	public HeaderFactory getHeaderFactory() {
 		return headerFactory;
@@ -83,7 +83,7 @@ public class ControlsBuilding implements HeaderPaneFactory, HeadersFactory, Head
 	}
 
 	/**
-	 * @return Factory for creating {@link ContentWrapper}.
+	 * {@return factory for creating {@link ContentWrapper}}
 	 */
 	public ContentWrapperFactory getContentWrapperFactory() {
 		return contentWrapperFactory;
@@ -101,7 +101,7 @@ public class ControlsBuilding implements HeaderPaneFactory, HeadersFactory, Head
 	}
 
 	/**
-	 * @return Factory for creating {@link PixelCanvas}.
+	 * {@return factory for creating {@link PixelCanvas}}
 	 */
 	public CanvasFactory getCanvasFactory() {
 		return canvasFactory;

--- a/core/src/main/java/software/coley/bentofx/building/DockBuilding.java
+++ b/core/src/main/java/software/coley/bentofx/building/DockBuilding.java
@@ -27,17 +27,17 @@ public class DockBuilding {
 	}
 
 	/**
-	 * @return New dockable.
+	 * {@return new dockable}
 	 */
 	public Dockable dockable() {
 		return dockable(uid("dockable"));
 	}
 
 	/**
+	 * {@return new dockable}
+	 *
 	 * @param identifier
 	 * 		Identifier to assign to the created dockable.
-	 *
-	 * @return New dockable.
 	 */
 	public Dockable dockable(String identifier) {
 		return new Dockable(bento, identifier);
@@ -68,34 +68,34 @@ public class DockBuilding {
 	}
 
 	/**
-	 * @return New branch container.
+	 * {@return new branch container}
 	 */
 	public DockContainerBranch branch() {
 		return branch(uid("cbranch"));
 	}
 
 	/**
+	 * {@return new branch container}
+	 *
 	 * @param identifier
 	 * 		Identifier to assign to the created container.
-	 *
-	 * @return New branch container.
 	 */
 	public DockContainerBranch branch(String identifier) {
 		return new DockContainerBranch(bento, identifier);
 	}
 
 	/**
-	 * @return New leaf container.
+	 * {@return new leaf container}
 	 */
 	public DockContainerLeaf leaf() {
 		return leaf(uid("cleaf"));
 	}
 
 	/**
+	 * {@return new leaf container}
+	 *
 	 * @param identifier
 	 * 		Identifier to assign to the created container.
-	 *
-	 * @return New branch container.
 	 */
 	public DockContainerLeaf leaf(String identifier) {
 		return new DockContainerLeaf(bento, identifier);

--- a/core/src/main/java/software/coley/bentofx/building/HeaderFactory.java
+++ b/core/src/main/java/software/coley/bentofx/building/HeaderFactory.java
@@ -11,12 +11,12 @@ import software.coley.bentofx.dockable.Dockable;
  */
 public interface HeaderFactory {
 	/**
+	 * {@return new header}
+	 *
 	 * @param dockable
 	 * 		Dockable to wrap.
 	 * @param parentPane
 	 * 		Parent header pane.
-	 *
-	 * @return New header.
 	 */
 	Header newHeader(Dockable dockable, HeaderPane parentPane);
 }

--- a/core/src/main/java/software/coley/bentofx/building/HeaderPaneFactory.java
+++ b/core/src/main/java/software/coley/bentofx/building/HeaderPaneFactory.java
@@ -10,10 +10,10 @@ import software.coley.bentofx.layout.container.DockContainerLeaf;
  */
 public interface HeaderPaneFactory {
 	/**
+	 * {@return new header pane}
+	 *
 	 * @param container
 	 * 		Parent container.
-	 *
-	 * @return New header pane.
 	 */
 	HeaderPane newHeaderPane(DockContainerLeaf container);
 }

--- a/core/src/main/java/software/coley/bentofx/building/HeadersFactory.java
+++ b/core/src/main/java/software/coley/bentofx/building/HeadersFactory.java
@@ -13,14 +13,14 @@ import software.coley.bentofx.layout.container.DockContainerLeaf;
  */
 public interface HeadersFactory {
 	/**
+	 * {@return newly created headers}
+	 *
 	 * @param container
 	 * 		Associated container.
 	 * @param orientation
 	 * 		Orientation of the headers.
 	 * @param side
 	 * 		Side this headers bar will be located at.
-	 *
-	 * @return Newly created headers.
 	 */
 	Headers newHeaders(DockContainerLeaf container, Orientation orientation, Side side);
 }

--- a/core/src/main/java/software/coley/bentofx/building/PlaceholderBuilding.java
+++ b/core/src/main/java/software/coley/bentofx/building/PlaceholderBuilding.java
@@ -21,7 +21,7 @@ public class PlaceholderBuilding implements DockablePlaceholderFactory, DockCont
 	private DockContainerLeafPlaceholderFactory containerPlaceholderFactory = container -> new Pane();
 
 	/**
-	 * @return Current placeholder factory for dockables with no content to show.
+	 * {@return current placeholder factory for dockables with no content to show}
 	 */
 	public DockablePlaceholderFactory getDockablePlaceholderFactory() {
 		return dockablePlaceholderFactory;
@@ -36,7 +36,7 @@ public class PlaceholderBuilding implements DockablePlaceholderFactory, DockCont
 	}
 
 	/**
-	 * @return Current placeholder factory for containers with no content to show.
+	 * {@return current placeholder factory for containers with no content to show}
 	 */
 	public DockContainerLeafPlaceholderFactory getContainerPlaceholderFactory() {
 		return containerPlaceholderFactory;

--- a/core/src/main/java/software/coley/bentofx/building/SceneFactory.java
+++ b/core/src/main/java/software/coley/bentofx/building/SceneFactory.java
@@ -12,6 +12,8 @@ import software.coley.bentofx.control.DragDropStage;
  */
 public interface SceneFactory {
 	/**
+	 * {@return newly created scene}
+	 *
 	 * @param sourceScene
 	 * 		Original scene to copy state from.
 	 * @param content
@@ -20,8 +22,6 @@ public interface SceneFactory {
 	 * 		Content width.
 	 * @param height
 	 * 		Content height.
-	 *
-	 * @return Newly created scene.
 	 */
 	Scene newScene(@Nullable Scene sourceScene, Region content, double width, double height);
 }

--- a/core/src/main/java/software/coley/bentofx/building/StageFactory.java
+++ b/core/src/main/java/software/coley/bentofx/building/StageFactory.java
@@ -11,10 +11,10 @@ import software.coley.bentofx.control.DragDropStage;
  */
 public interface StageFactory {
 	/**
+	 * {@return newly created stage}
+	 *
 	 * @param sourceStage
 	 * 		Original stage to copy state from.
-	 *
-	 * @return Newly created stage.
 	 */
 	DragDropStage newStage(@Nullable Stage sourceStage);
 }

--- a/core/src/main/java/software/coley/bentofx/control/Header.java
+++ b/core/src/main/java/software/coley/bentofx/control/Header.java
@@ -522,7 +522,7 @@ public class Header extends Region {
 	}
 
 	/**
-	 * @return Wrapped dockable.
+	 * {@return wrapped dockable}
 	 */
 	public Dockable getDockable() {
 		return dockable;

--- a/core/src/main/java/software/coley/bentofx/control/HeaderPane.java
+++ b/core/src/main/java/software/coley/bentofx/control/HeaderPane.java
@@ -348,7 +348,7 @@ public class HeaderPane extends BorderPane {
 	}
 
 	/**
-	 * @return New button that displays all dockables in this space.
+	 * {@return new button that displays all dockables in this space}
 	 */
 	protected Button createDockableListButton() {
 		Button button = new Button("▼");
@@ -397,10 +397,10 @@ public class HeaderPane extends BorderPane {
 	}
 
 	/**
+	 * {@return associated header within this pane that represents the given dockable}
+	 *
 	 * @param dockable
 	 * 		Some dockable.
-	 *
-	 * @return Associated header within this pane that represents the given dockable.
 	 */
 	@Nullable
 	public Header getHeader(@Nullable Dockable dockable) {
@@ -413,21 +413,21 @@ public class HeaderPane extends BorderPane {
 	}
 
 	/**
-	 * @return Parent container.
+	 * {@return parent container}
 	 */
 	public DockContainerLeaf getContainer() {
 		return container;
 	}
 
 	/**
-	 * @return The border-pane that holds the currently selected {@link Dockable#getNode()}.
+	 * {@return the border-pane that holds the currently selected {@link Dockable#getNode()}}
 	 */
 	public ContentWrapper getContentWrapper() {
 		return contentWrapper;
 	}
 
 	/**
-	 * @return The linear-item-pane holding {@link Header} children.
+	 * {@return the linear-item-pane holding {@link Header} children}
 	 */
 	@Nullable
 	public Headers getHeaders() {

--- a/core/src/main/java/software/coley/bentofx/control/LinearItemPane.java
+++ b/core/src/main/java/software/coley/bentofx/control/LinearItemPane.java
@@ -44,22 +44,22 @@ public class LinearItemPane extends Pane {
 	}
 
 	/**
-	 * @return Orientation of this linear pane.
+	 * {@return orientation of this linear pane}
 	 */
 	public Orientation getOrientation() {
 		return orientation;
 	}
 
 	/**
-	 * @return {@code true} when children overflow beyond the visible bounds of this pane.
-	 * {@code false} when all children are visible in-bounds.
+	 * {@return {@code true} when children overflow beyond the visible bounds of this pane, or
+	 * {@code false} when all children are visible in-bounds}
 	 */
 	public BooleanProperty overflowingProperty() {
 		return overflowing;
 	}
 
 	/**
-	 * @return A child to keep in view.
+	 * {@return a child to keep in view}
 	 */
 	public ObjectProperty<Node> keepInViewProperty() {
 		return keepInView;

--- a/core/src/main/java/software/coley/bentofx/control/canvas/ArgbSource.java
+++ b/core/src/main/java/software/coley/bentofx/control/canvas/ArgbSource.java
@@ -11,27 +11,30 @@ import java.util.Objects;
  */
 public interface ArgbSource {
 	/**
-	 * @return Image width.
+	 * {@return image width}
 	 */
 	int getWidth();
 
 	/**
-	 * @return Image height.
+	 * {@return image height}
 	 */
 	int getHeight();
 
 	/**
+	 * {@return ARGB {@code int} at coordinate, defaulting to {@code 0} for any coordinate out of
+	 * the image bounds}
+	 *
 	 * @param x
 	 * 		Image X coordinate.
 	 * @param y
 	 * 		Image X coordinate.
-	 *
-	 * @return ARGB {@code int} at coordinate.
-	 * Defaults to {@code 0} for any coordinate out of the image bounds.
 	 */
 	int getArgb(int x, int y);
 
 	/**
+	 * {@return ARGB {@code int[]} at coordinates for the given width/height, or
+	 * {@code null} when coordinates are out of the image bounds}
+	 *
 	 * @param x
 	 * 		Image X coordinate.
 	 * @param y
@@ -40,14 +43,11 @@ public interface ArgbSource {
 	 * 		Width of image section to grab.
 	 * @param height
 	 * 		Height of image section to grab.
-	 *
-	 * @return ARGB {@code int[]} at coordinates for the given width/height.
-	 * {@code null} when coordinates are out of the image bounds.
 	 */
 	int @Nullable [] getArgb(int x, int y, int width, int height);
 
 	/**
-	 * @return ARGB {@code int[]} for the full image.
+	 * {@return ARGB {@code int[]} for the full image}
 	 */
 	default int[] getArgb() {
 		return Objects.requireNonNull(getArgb(0, 0, getWidth(), getHeight()),

--- a/core/src/main/java/software/coley/bentofx/control/canvas/PixelCanvas.java
+++ b/core/src/main/java/software/coley/bentofx/control/canvas/PixelCanvas.java
@@ -354,10 +354,10 @@ public class PixelCanvas extends Region {
 	}
 
 	/**
+	 * {@return generated hash}
+	 *
 	 * @param values
 	 * 		Values to hash.
-	 *
-	 * @return Generated hash.
 	 */
 	protected static int hash(int... values) {
 		int hash = values[0];

--- a/core/src/main/java/software/coley/bentofx/control/canvas/PixelPainter.java
+++ b/core/src/main/java/software/coley/bentofx/control/canvas/PixelPainter.java
@@ -267,12 +267,12 @@ public interface PixelPainter<B extends Buffer> {
 	void clear();
 
 	/**
-	 * @return Backing buffer.
+	 * {@return backing buffer}
 	 */
 	B getBuffer();
 
 	/**
-	 * @return Pixel format for contents in this painter's buffer.
+	 * {@return pixel format for contents in this painter's buffer}
 	 */
 	PixelFormat<B> getPixelFormat();
 }

--- a/core/src/main/java/software/coley/bentofx/dockable/Dockable.java
+++ b/core/src/main/java/software/coley/bentofx/dockable/Dockable.java
@@ -92,8 +92,8 @@ public class Dockable implements BentoBacked, Identifiable {
 	}
 
 	/**
-	 * @return Path to this dockable in the current bento instance.
-	 * {@code null} if this dockable has no {@link #getContainer() parent container}.
+	 * {@return path to this dockable in the current bento instance, or
+	 * {@code null} if this dockable has no {@link #getContainer() parent container}}
 	 */
 	@Nullable
 	public DockablePath getPath() {
@@ -119,7 +119,7 @@ public class Dockable implements BentoBacked, Identifiable {
 	}
 
 	/**
-	 * @return Current title.
+	 * {@return current title}
 	 */
 	public String getTitle() {
 		if (title == null)
@@ -128,7 +128,7 @@ public class Dockable implements BentoBacked, Identifiable {
 	}
 
 	/**
-	 * @return Title property.
+	 * {@return title property}
 	 */
 	public StringProperty titleProperty() {
 		if (title == null)
@@ -145,7 +145,7 @@ public class Dockable implements BentoBacked, Identifiable {
 	}
 
 	/**
-	 * @return Current tooltip.
+	 * {@return current tooltip}
 	 */
 	@Nullable
 	public Tooltip getTooltip() {
@@ -155,7 +155,7 @@ public class Dockable implements BentoBacked, Identifiable {
 	}
 
 	/**
-	 * @return Tooltip property.
+	 * {@return tooltip property}
 	 */
 	public ObjectProperty<Tooltip> tooltipProperty() {
 		if (tooltip == null)
@@ -172,7 +172,7 @@ public class Dockable implements BentoBacked, Identifiable {
 	}
 
 	/**
-	 * @return Current icon factory.
+	 * {@return current icon factory}
 	 */
 	@Nullable
 	public DockableIconFactory getIconFactory() {
@@ -182,7 +182,7 @@ public class Dockable implements BentoBacked, Identifiable {
 	}
 
 	/**
-	 * @return Icon factory property.
+	 * {@return icon factory property}
 	 */
 	public ObjectProperty<DockableIconFactory> iconFactoryProperty() {
 		if (iconFactory == null) iconFactory = new SimpleObjectProperty<>();
@@ -198,7 +198,7 @@ public class Dockable implements BentoBacked, Identifiable {
 	}
 
 	/**
-	 * @return Current context menu factory.
+	 * {@return current context menu factory}
 	 */
 	@Nullable
 	public DockableMenuFactory getContextMenuFactory() {
@@ -208,7 +208,7 @@ public class Dockable implements BentoBacked, Identifiable {
 	}
 
 	/**
-	 * @return Context menu factory property.
+	 * {@return context menu factory property}
 	 */
 	public ObjectProperty<DockableMenuFactory> contextMenuFactoryProperty() {
 		if (contextMenuFactory == null)
@@ -225,7 +225,7 @@ public class Dockable implements BentoBacked, Identifiable {
 	}
 
 	/**
-	 * @return Current node to display when this dockable is selected.
+	 * {@return current node to display when this dockable is selected}
 	 */
 	@Nullable
 	public Node getNode() {
@@ -235,7 +235,7 @@ public class Dockable implements BentoBacked, Identifiable {
 	}
 
 	/**
-	 * @return Node to display when this dockable is selected.
+	 * {@return node to display when this dockable is selected}
 	 */
 	public ObjectProperty<Node> nodeProperty() {
 		if (node == null)
@@ -252,7 +252,7 @@ public class Dockable implements BentoBacked, Identifiable {
 	}
 
 	/**
-	 * @return Current parent container.
+	 * {@return current parent container}
 	 */
 	@Nullable
 	public DockContainerLeaf getContainer() {
@@ -262,7 +262,7 @@ public class Dockable implements BentoBacked, Identifiable {
 	}
 
 	/**
-	 * @return Parent container property.
+	 * {@return parent container property}
 	 */
 	public ObjectProperty<DockContainerLeaf> containerProperty() {
 		if (container == null)
@@ -281,7 +281,7 @@ public class Dockable implements BentoBacked, Identifiable {
 	}
 
 	/**
-	 * @return Current drag group mask.
+	 * {@return current drag group mask}
 	 */
 	public int getDragGroupMask() {
 		if (dragGroupMask == null)
@@ -290,7 +290,7 @@ public class Dockable implements BentoBacked, Identifiable {
 	}
 
 	/**
-	 * @return Drag group mask property.
+	 * {@return drag group mask property}
 	 */
 	public IntegerProperty dragGroupMaskProperty() {
 		if (dragGroupMask == null)
@@ -307,7 +307,7 @@ public class Dockable implements BentoBacked, Identifiable {
 	}
 
 	/**
-	 * @return {@code true} if this dockable is closable. {@code false} if not closable.
+	 * {@return {@code true} if this dockable is closable, {@code false} if not closable}
 	 */
 	public boolean isClosable() {
 		if (closable == null)
@@ -316,7 +316,7 @@ public class Dockable implements BentoBacked, Identifiable {
 	}
 
 	/**
-	 * @return Closable property.
+	 * {@return closable property}
 	 */
 	public BooleanProperty closableProperty() {
 		if (closable == null)
@@ -333,7 +333,7 @@ public class Dockable implements BentoBacked, Identifiable {
 	}
 
 	/**
-	 * @return {@code true} if this dockable can be dragged. {@code false} if not draggable.
+	 * {@return {@code true} if this dockable can be dragged, {@code false} if not draggable}
 	 */
 	public boolean isCanBeDragged() {
 		if (canBeDragged == null)
@@ -342,7 +342,7 @@ public class Dockable implements BentoBacked, Identifiable {
 	}
 
 	/**
-	 * @return Draggable property.
+	 * {@return draggable property}
 	 */
 	public BooleanProperty canBeDraggedProperty() {
 		if (canBeDragged == null)
@@ -359,7 +359,7 @@ public class Dockable implements BentoBacked, Identifiable {
 	}
 
 	/**
-	 * @return {@code true} if this dockable can be drag-dropped to a new window. {@code false} to limit to cross-container dragging.
+	 * {@return {@code true} if this dockable can be drag-dropped to a new window, {@code false} to limit to cross-container dragging}
 	 */
 	public boolean isCanBeDroppedToNewWindow() {
 		if (canBeDroppedToNewWindow == null)
@@ -368,7 +368,7 @@ public class Dockable implements BentoBacked, Identifiable {
 	}
 
 	/**
-	 * @return Window droppable property.
+	 * {@return window droppable property}
 	 */
 	public BooleanProperty canBeDroppedToNewWindowProperty() {
 		if (canBeDroppedToNewWindow == null)

--- a/core/src/main/java/software/coley/bentofx/dockable/DockableIconFactory.java
+++ b/core/src/main/java/software/coley/bentofx/dockable/DockableIconFactory.java
@@ -11,10 +11,10 @@ import org.jspecify.annotations.Nullable;
  */
 public interface DockableIconFactory {
 	/**
+	 * {@return graphic for the dockable}
+	 *
 	 * @param dockable
 	 * 		Dockable to create a graphic for.
-	 *
-	 * @return Graphic for the dockable.
 	 */
 	@Nullable
 	Node build(Dockable dockable);

--- a/core/src/main/java/software/coley/bentofx/dockable/DockableMenuFactory.java
+++ b/core/src/main/java/software/coley/bentofx/dockable/DockableMenuFactory.java
@@ -10,10 +10,10 @@ import org.jspecify.annotations.Nullable;
  */
 public interface DockableMenuFactory {
 	/**
+	 * {@return context menu for the dockable}
+	 *
 	 * @param dockable
 	 * 		Dockable to create a context menu for.
-	 *
-	 * @return Context menu for the dockable.
 	 */
 	@Nullable
 	ContextMenu build(Dockable dockable);

--- a/core/src/main/java/software/coley/bentofx/dockable/DockablePlaceholderFactory.java
+++ b/core/src/main/java/software/coley/bentofx/dockable/DockablePlaceholderFactory.java
@@ -10,10 +10,10 @@ import javafx.scene.Node;
  */
 public interface DockablePlaceholderFactory {
 	/**
+	 * {@return placeholder for the dockable}
+	 *
 	 * @param dockable
 	 * 		Dockable to create a placeholder display for.
-	 *
-	 * @return Placeholder for the dockable.
 	 */
 	Node build(Dockable dockable);
 }

--- a/core/src/main/java/software/coley/bentofx/event/DockEvent.java
+++ b/core/src/main/java/software/coley/bentofx/event/DockEvent.java
@@ -96,14 +96,14 @@ public sealed interface DockEvent {
 		}
 
 		/**
-		 * @return Dockable being closed.
+		 * {@return dockable being closed}
 		 */
 		public Dockable dockable() {
 			return dockable;
 		}
 
 		/**
-		 * @return Container the dockable belongs to.
+		 * {@return container the dockable belongs to}
 		 */
 		public DockContainerLeaf container() {
 			return container;
@@ -117,7 +117,7 @@ public sealed interface DockEvent {
 		}
 
 		/**
-		 * @return {@code true} when this closure has been cancelled.
+		 * {@return {@code true} when this closure has been cancelled}
 		 */
 		public boolean isCancelled() {
 			return cancelled;

--- a/core/src/main/java/software/coley/bentofx/event/EventBus.java
+++ b/core/src/main/java/software/coley/bentofx/event/EventBus.java
@@ -79,7 +79,7 @@ public class EventBus {
 	}
 
 	/**
-	 * @return Generic event listeners.
+	 * {@return generic event listeners}
 	 */
 	public List<DockEventListener> getEventListeners() {
 		return Collections.unmodifiableList(eventListeners);
@@ -102,7 +102,7 @@ public class EventBus {
 	}
 
 	/**
-	 * @return Dockable opening listeners.
+	 * {@return dockable opening listeners}
 	 */
 	public List<DockableOpenListener> getDockableOpenListener() {
 		return Collections.unmodifiableList(openListeners);
@@ -125,7 +125,7 @@ public class EventBus {
 	}
 
 	/**
-	 * @return Dockable moving listeners.
+	 * {@return dockable moving listeners}
 	 */
 	public List<DockableMoveListener> getDockableMoveListener() {
 		return Collections.unmodifiableList(moveListeners);
@@ -148,7 +148,7 @@ public class EventBus {
 	}
 
 	/**
-	 * @return Dockable closing listeners.
+	 * {@return dockable closing listeners}
 	 */
 	public List<DockableCloseListener> getDockableCloseListener() {
 		return Collections.unmodifiableList(closeListeners);
@@ -171,7 +171,7 @@ public class EventBus {
 	}
 
 	/**
-	 * @return Dockable selecting listeners.
+	 * {@return dockable selecting listeners}
 	 */
 	public List<DockableSelectListener> getDockableSelectListener() {
 		return Collections.unmodifiableList(selectListeners);

--- a/core/src/main/java/software/coley/bentofx/layout/DockContainer.java
+++ b/core/src/main/java/software/coley/bentofx/layout/DockContainer.java
@@ -22,7 +22,7 @@ import java.util.List;
  */
 public sealed interface DockContainer extends BentoBacked, Identifiable permits DockContainerBranch, DockContainerLeaf {
 	/**
-	 * @return Path to this container from the root container that holds this container.
+	 * {@return path to this container from the root container that holds this container}
 	 */
 	default DockContainerPath getPath() {
 		DockContainer parent = getParentContainer();
@@ -32,7 +32,7 @@ public sealed interface DockContainer extends BentoBacked, Identifiable permits 
 	}
 
 	/**
-	 * @return Parent container that holds this container. {@code null} when this container is a root.
+	 * {@return parent container that holds this container, or {@code null} when this container is a root}
 	 */
 	@Nullable
 	DockContainerBranch getParentContainer();
@@ -56,23 +56,23 @@ public sealed interface DockContainer extends BentoBacked, Identifiable permits 
 	void removeAsParentContainer(DockContainerBranch parent);
 
 	/**
+	 * {@return {@code true} when the visit shall continue}
+	 *
 	 * @param visitor
 	 * 		Visitor to control continued traversal.
-	 *
-	 * @return {@code true} when the visit shall continue.
 	 */
 	boolean visit(SearchVisitor visitor);
 
 	/**
-	 * @return Unmodifiable list of dockables within this container.
+	 * {@return unmodifiable list of dockables within this container}
 	 */
 	List<Dockable> getDockables();
 
 	/**
+	 * {@return {@code true} if one or more of the dockables were added}
+	 *
 	 * @param dockables
 	 * 		Dockables to add.
-	 *
-	 * @return {@code true} if one or more of the dockables were added.
 	 */
 	default boolean addDockables(Dockable... dockables) {
 		boolean changed = false;
@@ -82,36 +82,36 @@ public sealed interface DockContainer extends BentoBacked, Identifiable permits 
 	}
 
 	/**
+	 * {@return {@code true} when added}
+	 *
 	 * @param dockable
 	 * 		Dockable to add.
-	 *
-	 * @return {@code true} when added.
 	 */
 	boolean addDockable(Dockable dockable);
 
 	/**
+	 * {@return {@code true} when added}
+	 *
 	 * @param dockable
 	 * 		Dockable to add.
 	 * @param index
 	 * 		Index to add the dockable at.
-	 *
-	 * @return {@code true} when added.
 	 */
 	boolean addDockable(int index, Dockable dockable);
 
 	/**
+	 * {@return {@code true} when removed}
+	 *
 	 * @param dockable
 	 * 		Dockable to remove.
-	 *
-	 * @return {@code true} when removed.
 	 */
 	boolean removeDockable(Dockable dockable);
 
 	/**
+	 * {@return {@code true} when removed}
+	 *
 	 * @param dockable
 	 * 		Dockable to close and then remove.
-	 *
-	 * @return {@code true} when removed.
 	 */
 	boolean closeDockable(Dockable dockable);
 
@@ -128,7 +128,7 @@ public sealed interface DockContainer extends BentoBacked, Identifiable permits 
 	}
 
 	/**
-	 * @return {@code true} to {@link #removeFromParent() prune} when this container has no remaining dockables.
+	 * {@return {@code true} to {@link #removeFromParent() prune} when this container has no remaining dockables}
 	 */
 	boolean doPruneWhenEmpty();
 
@@ -139,7 +139,7 @@ public sealed interface DockContainer extends BentoBacked, Identifiable permits 
 	void setPruneWhenEmpty(boolean pruneWhenEmpty);
 
 	/**
-	 * @return Self, cast to region.
+	 * {@return self, cast to region}
 	 */
 	default Region asRegion() {
 		return (Region) this;

--- a/core/src/main/java/software/coley/bentofx/layout/container/DockContainerBranch.java
+++ b/core/src/main/java/software/coley/bentofx/layout/container/DockContainerBranch.java
@@ -84,10 +84,10 @@ public non-sealed class DockContainerBranch extends SplitPane implements DockCon
 	}
 
 	/**
+	 * {@return {@code true} if one or more of the containers were added}
+	 *
 	 * @param containers
 	 * 		Containers to add.
-	 *
-	 * @return {@code true} if one or more of the containers were added.
 	 */
 	public boolean addContainers(DockContainer... containers) {
 		boolean changed = false;
@@ -97,22 +97,22 @@ public non-sealed class DockContainerBranch extends SplitPane implements DockCon
 	}
 
 	/**
+	 * {@return {@code true} when added}
+	 *
 	 * @param container
 	 * 		Container to add.
-	 *
-	 * @return {@code true} when added.
 	 */
 	public boolean addContainer(DockContainer container) {
 		return addContainer(childContainers.size(), container);
 	}
 
 	/**
+	 * {@return {@code true} when added}
+	 *
 	 * @param index
 	 * 		Index to add the container at.
 	 * @param container
 	 * 		Container to add.
-	 *
-	 * @return {@code true} when added.
 	 */
 	public boolean addContainer(int index, DockContainer container) {
 		if (index < 0 || index > childContainers.size())
@@ -131,12 +131,12 @@ public non-sealed class DockContainerBranch extends SplitPane implements DockCon
 	}
 
 	/**
+	 * {@return {@code true} when replaced}
+	 *
 	 * @param child
 	 * 		A child container within this container.
 	 * @param replacement
 	 * 		A container to replace the existing child with.
-	 *
-	 * @return {@code true} when replaced.
 	 */
 	public boolean replaceContainer(DockContainer child, DockContainer replacement) {
 		if (childContainers.contains(child)) {
@@ -158,10 +158,10 @@ public non-sealed class DockContainerBranch extends SplitPane implements DockCon
 	}
 
 	/**
+	 * {@return {@code true} when removed}
+	 *
 	 * @param child
 	 * 		A child container within this container.
-	 *
-	 * @return {@code true} when removed.
 	 */
 	public boolean removeContainer(DockContainer child) {
 		if (childContainers.remove(child)) {
@@ -187,12 +187,12 @@ public non-sealed class DockContainerBranch extends SplitPane implements DockCon
 	}
 
 	/**
+	 * {@return {@code true} when updated}
+	 *
 	 * @param child
 	 * 		A child container within this container.
 	 * @param size
 	 * 		Size in pixels to set the child container width or height to <i>(Depending on {@link #getOrientation()})</i>
-	 *
-	 * @return {@code true} when updated.
 	 */
 	public boolean setContainerSizePx(DockContainer child, double size) {
 		return setContainerSizePx0(child, size, true);
@@ -252,12 +252,12 @@ public non-sealed class DockContainerBranch extends SplitPane implements DockCon
 	}
 
 	/**
+	 * {@return {@code true} when updated}
+	 *
 	 * @param child
 	 * 		A child container within this container.
 	 * @param percent
 	 * 		Size in percentage of the total width/height of this container to set the child container to <i>(Depending on {@link #getOrientation()})</i>
-	 *
-	 * @return {@code true} when updated.
 	 */
 	public boolean setContainerSizePercent(DockContainer child, double percent) {
 		// TODO: This does not need to be queued in the same way the SizePx does however...
@@ -283,10 +283,10 @@ public non-sealed class DockContainerBranch extends SplitPane implements DockCon
 	}
 
 	/**
+	 * {@return {@code true} if the child is resizable}
+	 *
 	 * @param child
 	 * 		A child container within this container.
-	 *
-	 * @return {@code true} if the child is resizable.
 	 */
 	public boolean isContainerResizable(DockContainer child) {
 		// Get our direct children that are dividers.
@@ -313,12 +313,12 @@ public non-sealed class DockContainerBranch extends SplitPane implements DockCon
 	}
 
 	/**
+	 * {@return {@code true} when updated}
+	 *
 	 * @param child
 	 * 		A child container within this container.
 	 * @param resizable
 	 * 		Resizable state to apply to the child.
-	 *
-	 * @return {@code true} when updated.
 	 */
 	public boolean setContainerResizable(DockContainer child, boolean resizable) {
 		// We rely on the split-pane skin having laid out the divders for this implementation, so we need to delegate
@@ -354,22 +354,22 @@ public non-sealed class DockContainerBranch extends SplitPane implements DockCon
 	}
 
 	/**
+	 * {@return {@code true} if the child is collapsed}
+	 *
 	 * @param child
 	 * 		A child container within this container.
-	 *
-	 * @return {@code true} if the child is collapsed.
 	 */
 	public boolean isContainerCollapsed(DockContainer child) {
 		return child instanceof DockContainerLeaf leaf && leaf.isCollapsed();
 	}
 
 	/**
+	 * {@return {@code true} when updated}
+	 *
 	 * @param child
 	 * 		A child container within this container.
 	 * @param collapse
 	 * 		Collapsed state to apply to the child.
-	 *
-	 * @return {@code true} when updated.
 	 */
 	public boolean setContainerCollapsed(DockContainerLeaf child, boolean collapse) {
 		// Skip if there is nothing to branch between. If there is only one child collapsing makes no sense
@@ -421,7 +421,7 @@ public non-sealed class DockContainerBranch extends SplitPane implements DockCon
 	}
 
 	/**
-	 * @return Unmodifiable list of containers within this container.
+	 * {@return unmodifiable list of containers within this container}
 	 */
 	public ObservableList<DockContainer> getChildContainers() {
 		return childContainersView;

--- a/core/src/main/java/software/coley/bentofx/layout/container/DockContainerLeaf.java
+++ b/core/src/main/java/software/coley/bentofx/layout/container/DockContainerLeaf.java
@@ -123,10 +123,10 @@ public non-sealed class DockContainerLeaf extends StackPane implements DockConta
 	}
 
 	/**
+	 * {@return {@code true} when updated}
+	 *
 	 * @param dockable
 	 * 		Dockable to mark as selected.
-	 *
-	 * @return {@code true} when updated.
 	 */
 	public boolean selectDockable(@Nullable Dockable dockable) {
 		// Special case for clearing selection
@@ -226,12 +226,12 @@ public non-sealed class DockContainerLeaf extends StackPane implements DockConta
 	}
 
 	/**
+	 * {@return {@code true} when this container can receive the dockable}
+	 *
 	 * @param dockable
 	 * 		Some dockable.
 	 * @param receivedSide
 	 * 		The side the dockable will be dropped to as part of a DnD operation.
-	 *
-	 * @return {@code true} when this container can receive the dockable.
 	 */
 	public boolean canReceiveDockable(Dockable dockable, @Nullable Side receivedSide) {
 		// Must not already have the given dockable if not splitting.
@@ -310,14 +310,14 @@ public non-sealed class DockContainerLeaf extends StackPane implements DockConta
 	}
 
 	/**
-	 * @return Overlay canvas.
+	 * {@return overlay canvas}
 	 */
 	public PixelCanvas getCanvas() {
 		return canvas;
 	}
 
 	/**
-	 * @return {@code true} when collapsed.
+	 * {@return {@code true} when collapsed}
 	 */
 	public boolean isCollapsed() {
 		return getPseudoClassStates().contains(PSEUDO_COLLAPSED);
@@ -327,7 +327,7 @@ public non-sealed class DockContainerLeaf extends StackPane implements DockConta
 	 * @param selectedDockable
 	 * 		Dockable whose interaction is causing the collapsed state to toggle.
 	 *
-	 * @return {@link #isCollapsed()} after toggling.
+	 * {@return {@link #isCollapsed()} after toggling}
 	 */
 	public boolean toggleCollapse(@Nullable Dockable selectedDockable) {
 		boolean result;
@@ -386,7 +386,7 @@ public non-sealed class DockContainerLeaf extends StackPane implements DockConta
 	}
 
 	/**
-	 * @return Collapsed size of this container.
+	 * {@return collapsed size of this container}
 	 */
 	protected double getCollapsedSize() {
 		return switch (getSide()) {
@@ -397,7 +397,7 @@ public non-sealed class DockContainerLeaf extends StackPane implements DockConta
 	}
 
 	/**
-	 * @return Uncollapsed size of this container.
+	 * {@return uncollapsed size of this container}
 	 */
 	protected double getUncollapsedSize() {
 		return switch (getSide()) {
@@ -408,10 +408,10 @@ public non-sealed class DockContainerLeaf extends StackPane implements DockConta
 	}
 
 	/**
+	 * {@return associated header within this container that represents the given dockable}
+	 *
 	 * @param dockable
 	 * 		Some dockable.
-	 *
-	 * @return Associated header within this container that represents the given dockable.
 	 */
 	@Nullable
 	public Header getHeader(Dockable dockable) {
@@ -419,8 +419,8 @@ public non-sealed class DockContainerLeaf extends StackPane implements DockConta
 	}
 
 	/**
-	 * @return Side of this container to place {@link Header} displays on.
-	 * {@code null} to not display any headers.
+	 * {@return side of this container to place {@link Header} displays on, or
+	 * {@code null} to not display any headers}
 	 */
 	@Nullable
 	public Side getSide() {
@@ -437,7 +437,7 @@ public non-sealed class DockContainerLeaf extends StackPane implements DockConta
 	}
 
 	/**
-	 * @return {@link Header} display side property.
+	 * {@return {@link Header} display side property}
 	 */
 	public ObjectProperty<Side> sideProperty() {
 		return side;
@@ -466,14 +466,14 @@ public non-sealed class DockContainerLeaf extends StackPane implements DockConta
 	}
 
 	/**
-	 * @return Collapsed state property.
+	 * {@return collapsed state property}
 	 */
 	public BooleanProperty collapsedProperty() {
 		return collapsed;
 	}
 
 	/**
-	 * @return Context menu for this container.
+	 * {@return context menu for this container}
 	 */
 	@Nullable
 	public ContextMenu buildContextMenu() {
@@ -482,7 +482,7 @@ public non-sealed class DockContainerLeaf extends StackPane implements DockConta
 	}
 
 	/**
-	 * @return Menu factory for this container.
+	 * {@return menu factory for this container}
 	 */
 	@Nullable
 	public DockContainerLeafMenuFactory getMenuFactory() {
@@ -490,7 +490,7 @@ public non-sealed class DockContainerLeaf extends StackPane implements DockConta
 	}
 
 	/**
-	 * @return Menu factory property.
+	 * {@return menu factory property}
 	 */
 	public ObjectProperty<DockContainerLeafMenuFactory> menuFactoryProperty() {
 		return menuFactory;
@@ -505,7 +505,7 @@ public non-sealed class DockContainerLeaf extends StackPane implements DockConta
 	}
 
 	/**
-	 * @return {@code true} if this leaf can be split via drag-n-drop operations.
+	 * {@return {@code true} if this leaf can be split via drag-n-drop operations}
 	 */
 	public boolean isCanSplit() {
 		if (parent == null) return false;
@@ -514,7 +514,7 @@ public non-sealed class DockContainerLeaf extends StackPane implements DockConta
 	}
 
 	/**
-	 * @return Splittable property.
+	 * {@return splittable property}
 	 */
 	public BooleanProperty canSplitProperty() {
 		if (canSplit == null) canSplit = new SimpleBooleanProperty(true);

--- a/core/src/main/java/software/coley/bentofx/layout/container/DockContainerLeafMenuFactory.java
+++ b/core/src/main/java/software/coley/bentofx/layout/container/DockContainerLeafMenuFactory.java
@@ -10,10 +10,10 @@ import org.jspecify.annotations.Nullable;
  */
 public interface DockContainerLeafMenuFactory {
 	/**
+	 * {@return context menu for the container}
+	 *
 	 * @param container
 	 * 		Container to create a context menu for.
-	 *
-	 * @return Context menu for the container.
 	 */
 	@Nullable
 	ContextMenu build(DockContainerLeaf container);

--- a/core/src/main/java/software/coley/bentofx/layout/container/DockContainerLeafPlaceholderFactory.java
+++ b/core/src/main/java/software/coley/bentofx/layout/container/DockContainerLeafPlaceholderFactory.java
@@ -10,10 +10,10 @@ import javafx.scene.Node;
  */
 public interface DockContainerLeafPlaceholderFactory {
 	/**
+	 * {@return placeholder for the container}
+	 *
 	 * @param container
 	 * 		Container to create a placeholder display for.
-	 *
-	 * @return Placeholder for the container.
 	 */
 	Node build(DockContainerLeaf container);
 }

--- a/core/src/main/java/software/coley/bentofx/path/BentoPath.java
+++ b/core/src/main/java/software/coley/bentofx/path/BentoPath.java
@@ -9,7 +9,7 @@ import software.coley.bentofx.layout.DockContainer;
  */
 public sealed interface BentoPath permits DockContainerPath, DockablePath {
 	/**
-	 * @return Root container of the path.
+	 * {@return root container of the path}
 	 */
 	DockContainer rootContainer();
 }

--- a/core/src/main/java/software/coley/bentofx/path/DockContainerPath.java
+++ b/core/src/main/java/software/coley/bentofx/path/DockContainerPath.java
@@ -15,10 +15,10 @@ import java.util.List;
  */
 public record DockContainerPath(List<DockContainer> containers) implements BentoPath {
 	/**
+	 * {@return new path with the given child at the end}
+	 *
 	 * @param child
 	 * 		Child to append to new path.
-	 *
-	 * @return New path with the given child at the end.
 	 */
 	public DockContainerPath withChild(DockContainer child) {
 		List<DockContainer> containersWithChild = new ArrayList<>(containers.size() + 1);
@@ -28,10 +28,10 @@ public record DockContainerPath(List<DockContainer> containers) implements Bento
 	}
 
 	/**
+	 * {@return new path with the given child at the end}
+	 *
 	 * @param child
 	 * 		Child to append to new path.
-	 *
-	 * @return New path with the given child at the end.
 	 */
 	public DockablePath withChild(Dockable child) {
 		return new DockablePath(containers, child);
@@ -44,7 +44,7 @@ public record DockContainerPath(List<DockContainer> containers) implements Bento
 	}
 
 	/**
-	 * @return Tail container in the path / intended target of the path.
+	 * {@return tail container in the path / intended target of the path}
 	 */
 	public DockContainer tailContainer() {
 		// There must always be at least one container since we must have a result for the path.

--- a/core/src/main/java/software/coley/bentofx/search/DockContainerVisitor.java
+++ b/core/src/main/java/software/coley/bentofx/search/DockContainerVisitor.java
@@ -41,7 +41,7 @@ public class DockContainerVisitor implements SearchVisitor {
 
 
 	/**
-	 * @return Matched container if found.
+	 * {@return matched container if found}
 	 */
 	@Nullable
 	public DockContainer getMatchedContainer() {

--- a/core/src/main/java/software/coley/bentofx/search/DockableVisitor.java
+++ b/core/src/main/java/software/coley/bentofx/search/DockableVisitor.java
@@ -33,7 +33,7 @@ public class DockableVisitor implements SearchVisitor {
 	}
 
 	/**
-	 * @return Matched dockable if found.
+	 * {@return matched dockable if found}
 	 */
 	@Nullable
 	public Dockable getMatchedDockable() {

--- a/core/src/main/java/software/coley/bentofx/search/SearchHandler.java
+++ b/core/src/main/java/software/coley/bentofx/search/SearchHandler.java
@@ -34,24 +34,24 @@ public class SearchHandler {
 	}
 
 	/**
+	 * {@return {@code true} when replacement was completed}
+	 *
 	 * @param identifier
 	 * 		Some {@link DockContainer#getIdentifier()}.
 	 * @param replacement
 	 * 		Content to replace the matched container with.
-	 *
-	 * @return {@code true} when replacement was completed.
 	 */
 	public boolean replaceContainer(String identifier, DockContainer replacement) {
 		return replaceContainer(identifier, () -> replacement);
 	}
 
 	/**
+	 * {@return {@code true} when replacement was completed}
+	 *
 	 * @param identifier
 	 * 		Some {@link DockContainer#getIdentifier()}.
 	 * @param replacement
 	 * 		Supplier of content to replace the matched container with.
-	 *
-	 * @return {@code true} when replacement was completed.
 	 */
 	public boolean replaceContainer(String identifier, Supplier<DockContainer> replacement) {
 		DockContainerPath container = container(identifier);
@@ -67,10 +67,10 @@ public class SearchHandler {
 	}
 
 	/**
+	 * {@return path to the matched container, if found}
+	 *
 	 * @param identifier
 	 * 		Some {@link DockContainer#getIdentifier()}.
-	 *
-	 * @return Path to the matched container, if found.
 	 */
 	@Nullable
 	public DockContainerPath container(String identifier) {
@@ -78,10 +78,10 @@ public class SearchHandler {
 	}
 
 	/**
+	 * {@return path to the first matched container, if found}
+	 *
 	 * @param predicate
 	 * 		Predicate to match against some container.
-	 *
-	 * @return Path to the first matched container, if found.
 	 */
 	@Nullable
 	public DockContainerPath container(Predicate<DockContainer> predicate) {
@@ -95,10 +95,10 @@ public class SearchHandler {
 	}
 
 	/**
+	 * {@return path to the associated {@link Dockable} if found}
+	 *
 	 * @param event
 	 * 		A drag event that may have a {@link Dockable} associated with it.
-	 *
-	 * @return Path to the associated {@link Dockable} if found.
 	 */
 	@Nullable
 	public DockablePath dockable(DragEvent event) {
@@ -107,10 +107,10 @@ public class SearchHandler {
 	}
 
 	/**
+	 * {@return path to the matched container, if found}
+	 *
 	 * @param identifier
 	 * 		Some {@link Dockable#getIdentifier()}.
-	 *
-	 * @return Path to the matched container, if found.
 	 */
 	@Nullable
 	public DockablePath dockable(String identifier) {
@@ -118,10 +118,10 @@ public class SearchHandler {
 	}
 
 	/**
+	 * {@return path to the first matched dockable, if found}
+	 *
 	 * @param predicate
 	 * 		Predicate to match against some dockable.
-	 *
-	 * @return Path to the first matched dockable, if found.
 	 */
 	@Nullable
 	public DockablePath dockable(Predicate<Dockable> predicate) {
@@ -135,7 +135,7 @@ public class SearchHandler {
 	}
 
 	/**
-	 * @return All found dockable paths in the current bento instance.
+	 * {@return all found dockable paths in the current bento instance}
 	 */
 	public List<DockablePath> allDockables() {
 		List<DockablePath> paths = new ArrayList<>();

--- a/core/src/main/java/software/coley/bentofx/search/SearchVisitor.java
+++ b/core/src/main/java/software/coley/bentofx/search/SearchVisitor.java
@@ -12,30 +12,30 @@ import software.coley.bentofx.layout.container.DockContainerLeaf;
  */
 public interface SearchVisitor {
 	/**
+	 * {@return {@code true} to continue visitation}
+	 *
 	 * @param container
 	 * 		Container to visit.
-	 *
-	 * @return {@code true} to continue visitation.
 	 */
 	default boolean visitBranch(DockContainerBranch container) {
 		return true;
 	}
 
 	/**
+	 * {@return {@code true} to continue visitation}
+	 *
 	 * @param container
 	 * 		Container to visit.
-	 *
-	 * @return {@code true} to continue visitation.
 	 */
 	default boolean visitLeaf(DockContainerLeaf container) {
 		return true;
 	}
 
 	/**
+	 * {@return {@code true} to continue visitation}
+	 *
 	 * @param dockable
 	 * 		Dockable to visit.
-	 *
-	 * @return {@code true} to continue visitation.
 	 */
 	default boolean visitDockable(Dockable dockable) {
 		return true;

--- a/core/src/main/java/software/coley/bentofx/util/BentoUtils.java
+++ b/core/src/main/java/software/coley/bentofx/util/BentoUtils.java
@@ -26,10 +26,10 @@ import java.util.function.Consumer;
  */
 public class BentoUtils {
 	/**
+	 * {@return respective orientation if it were to be used for a {@link HeaderPane}}
+	 *
 	 * @param side
 	 * 		Some side.
-	 *
-	 * @return Respective orientation if it were to be used for a {@link HeaderPane}.
 	 */
 	public static Orientation sideToOrientation(@Nullable Side side) {
 		return switch (side) {
@@ -40,14 +40,14 @@ public class BentoUtils {
 	}
 
 	/**
+	 * {@return the closest side for the given target position in the given region}
+	 *
 	 * @param target
 	 * 		Some target to base calculations in.
 	 * @param x
 	 * 		Target x.
 	 * @param y
 	 * 		Target y.
-	 *
-	 * @return The closest side for the given target position in the given region.
 	 */
 	@Nullable
 	public static Side computeClosestSide(Region target, double x, double y) {


### PR DESCRIPTION
# Closes #45
- Text-only change: no method signatures, behavior, or logic were touched.
- One "Boy Scout" fix: `DockBuilding.leaf(String)`'s doc had been copy-pasted from `branch(String)` — corrected while I was already editing.
